### PR TITLE
feature/1/버그수정

### DIFF
--- a/src/computer_use_training_generator/agent.py
+++ b/src/computer_use_training_generator/agent.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 
 from .models import AgentInvocationResult
-from .subprocess_utils import run_command
+from .subprocess_utils import command_to_shell_string, run_command
 
 
 def _parse_agent_json(stdout: str) -> dict:
@@ -13,12 +13,28 @@ def _parse_agent_json(stdout: str) -> dict:
     return payload
 
 
+def _format_command_failure(stage: str, result) -> str:
+    stdout_tail = result.stdout.strip()[-2000:]
+    stderr_tail = result.stderr.strip()[-2000:]
+    details = [
+        f"{stage} failed with exit code {result.returncode}",
+        f"command: {command_to_shell_string(result.command)}",
+        f"cwd: {result.cwd or ''}",
+    ]
+    if stdout_tail:
+        details.append(f"stdout_tail:\n{stdout_tail}")
+    if stderr_tail:
+        details.append(f"stderr_tail:\n{stderr_tail}")
+    return "\n".join(details)
+
+
 def _base_agent_command(
     *,
     agent_command: str,
     endpoint: str | None,
     config_path: str | None,
     reasoning_enabled: bool,
+    request_timeout_s: float | None = None,
 ) -> list[str]:
     command = [agent_command]
     if config_path:
@@ -27,6 +43,10 @@ def _base_agent_command(
         command.extend(["--endpoint", endpoint])
     if reasoning_enabled:
         command.append("--reasoning-enabled")
+    if request_timeout_s is not None:
+        timeout_value = str(float(request_timeout_s))
+        command.extend(["--load-request-timeout-s", timeout_value])
+        command.extend(["--run-request-timeout-s", timeout_value])
     return command
 
 
@@ -45,11 +65,12 @@ def bootstrap_agent(
         endpoint=endpoint,
         config_path=config_path,
         reasoning_enabled=reasoning_enabled,
+        request_timeout_s=timeout_s,
     )
     command.extend(["--model-id", model_id])
     result = run_command(command, cwd=cwd, timeout_s=timeout_s)
     if result.returncode != 0:
-        raise RuntimeError(f"agent bootstrap failed with exit code {result.returncode}")
+        raise RuntimeError(_format_command_failure("agent bootstrap", result))
     payload = _parse_agent_json(result.stdout)
     if not payload.get("ok", False):
         raise RuntimeError("agent bootstrap returned ok=false")
@@ -71,11 +92,12 @@ def run_agent_prompt(
         endpoint=endpoint,
         config_path=config_path,
         reasoning_enabled=reasoning_enabled,
+        request_timeout_s=timeout_s,
     )
     command.extend(["--prompt", prompt])
     result = run_command(command, cwd=cwd, timeout_s=timeout_s)
     if result.returncode != 0:
-        raise RuntimeError(f"agent prompt failed with exit code {result.returncode}")
+        raise RuntimeError(_format_command_failure("agent prompt", result))
     payload = _parse_agent_json(result.stdout)
     if not payload.get("ok", False):
         raise RuntimeError("agent prompt returned ok=false")

--- a/src/computer_use_training_generator/cli.py
+++ b/src/computer_use_training_generator/cli.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from pathlib import Path
+import shutil
+import subprocess
+import sys
 
 from .agent import bootstrap_agent, run_agent_prompt
 from .collector import collect_run_artifacts
@@ -10,8 +14,34 @@ from .config_utils import load_generator_config
 from .teacher import run_teacher
 
 
+def _find_existing_path(candidates: list[Path]) -> Path | None:
+    for candidate in candidates:
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            continue
+        if resolved.exists():
+            return resolved
+    return None
+
+
 def _default_config_path() -> Path:
-    return (Path(__file__).resolve().parents[2] / "config" / "generator.default.json").resolve()
+    candidates: list[Path] = []
+    cwd = Path.cwd()
+    candidates.append(cwd / "config" / "generator.default.json")
+
+    argv0 = Path(sys.argv[0]).resolve()
+    for parent in argv0.parents:
+        candidates.append(parent / "config" / "generator.default.json")
+
+    module_path = Path(__file__).resolve()
+    for parent in module_path.parents:
+        candidates.append(parent / "config" / "generator.default.json")
+
+    resolved = _find_existing_path(candidates)
+    if resolved is not None:
+        return resolved
+    return (cwd / "config" / "generator.default.json").resolve()
 
 
 def _load_config(path: str | None) -> tuple[dict, Path | None]:
@@ -49,6 +79,124 @@ def _build_effective_config(args: argparse.Namespace) -> tuple[dict, Path | None
     if getattr(args, "output_dir", None) is not None:
         config["output_dir"] = str(Path(args.output_dir).resolve())
     return config, config_path
+
+
+def _request_terminal_attention(message: str) -> None:
+    stream = sys.stderr if sys.stderr.isatty() else None
+    owned_stream = None
+    if stream is None:
+        tty_path = "CONOUT$" if os.name == "nt" else "/dev/tty"
+        try:
+            owned_stream = open(tty_path, "w", encoding="utf-8", buffering=1)
+            stream = owned_stream
+        except OSError:
+            return
+    try:
+        title = f"training-generator finished: {message}"
+        # Set a distinctive title first so external window-raise helpers can find it.
+        stream.write(f"\x1b]0;{title}\x07")
+        # Best-effort terminal attention request for interactive shells:
+        # de-iconify, raise window, then ring the bell.
+        stream.write("\n\x1b[1t\x1b[5t\a")
+        stream.write(f"[training-generator] {message}\n")
+        stream.flush()
+        _raise_terminal_window(title)
+    finally:
+        if owned_stream is not None:
+            owned_stream.close()
+
+
+def _raise_terminal_window(title: str) -> None:
+    if _raise_terminal_window_wsl(title):
+        return
+    if _raise_terminal_window_x11(title):
+        return
+
+
+def _raise_terminal_window_x11(title: str) -> bool:
+    if not os.environ.get("DISPLAY"):
+        return False
+    xdotool = shutil.which("xdotool")
+    if xdotool:
+        try:
+            subprocess.run(
+                [xdotool, "search", "--name", title, "windowraise", "--sync"],
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            return True
+        except OSError:
+            pass
+    wmctrl = shutil.which("wmctrl")
+    if wmctrl:
+        try:
+            subprocess.run(
+                [wmctrl, "-a", title],
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            return True
+        except OSError:
+            pass
+    return False
+
+
+def _raise_terminal_window_wsl(title: str) -> bool:
+    if not os.environ.get("WSL_DISTRO_NAME"):
+        return False
+    powershell = shutil.which("powershell.exe")
+    if not powershell:
+        return False
+    script = rf"""
+$title = {title!r}
+$sig = @'
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+public static class Win32Raise {{
+  public delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+  [DllImport("user32.dll")] public static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, IntPtr lParam);
+  [DllImport("user32.dll", CharSet = CharSet.Unicode)] public static extern int GetWindowText(IntPtr hWnd, StringBuilder text, int count);
+  [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr hWnd);
+  [DllImport("user32.dll")] public static extern bool ShowWindowAsync(IntPtr hWnd, int nCmdShow);
+  [DllImport("user32.dll")] public static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
+}}
+'@
+Add-Type -TypeDefinition $sig -ErrorAction SilentlyContinue | Out-Null
+$HWND_TOPMOST = [IntPtr](-1)
+$HWND_NOTOPMOST = [IntPtr](-2)
+$SWP_NOMOVE = 0x0002
+$SWP_NOSIZE = 0x0001
+$SWP_SHOWWINDOW = 0x0040
+$SWP_NOACTIVATE = 0x0010
+$flags = $SWP_NOMOVE -bor $SWP_NOSIZE -bor $SWP_SHOWWINDOW -bor $SWP_NOACTIVATE
+[Win32Raise]::EnumWindows({{
+  param($hWnd, $lParam)
+  if (-not [Win32Raise]::IsWindowVisible($hWnd)) {{ return $true }}
+  $sb = New-Object System.Text.StringBuilder 512
+  [void][Win32Raise]::GetWindowText($hWnd, $sb, $sb.Capacity)
+  $text = $sb.ToString()
+  if ($text -and $text.Contains($title)) {{
+    [void][Win32Raise]::ShowWindowAsync($hWnd, 9)
+    [void][Win32Raise]::SetWindowPos($hWnd, $HWND_TOPMOST, 0, 0, 0, 0, $flags)
+    [void][Win32Raise]::SetWindowPos($hWnd, $HWND_NOTOPMOST, 0, 0, 0, 0, $flags)
+    return $false
+  }}
+  return $true
+}}, [IntPtr]::Zero) | Out-Null
+"""
+    try:
+        subprocess.run(
+            [powershell, "-NoProfile", "-Command", script],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return True
+    except OSError:
+        return False
 
 
 def cmd_run_session(args: argparse.Namespace) -> int:
@@ -178,7 +326,11 @@ def build_parser() -> argparse.ArgumentParser:
 def main() -> int:
     parser = build_parser()
     args = parser.parse_args()
-    return int(args.func(args))
+    try:
+        return int(args.func(args))
+    finally:
+        if getattr(args, "command", None) == "run-session":
+            _request_terminal_attention("run-session finished")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 이번 반영 내용

`computer-use-training-generator`의 `run-session` 흐름을 기존의
`teacher 응답 전체 1개 -> agent 1회 실행`
에서
`teacher 응답 생성 -> teacher가 다시 순차 chunk plan 생성 -> chunk를 1개씩 agent에 순차 실행 -> 여러 agent run을 한 session으로 집계`
구조로 변경했다.

### 구현 사항

- `teacher.py`
  - teacher 원문 응답을 다시 teacher에게 넣어 strict JSON chunk plan을 생성하는 `split_teacher_response(...)` 추가
  - chunk 스키마는 `chunk_id`, `title`, `agent_prompt`, `success_hint`
  - split JSON 파싱 실패 시 teacher 원문 전체를 단일 chunk로 쓰는 fallback 유지
  - chunk 개수는 더 이상 고정 상한을 두지 않고, teacher가 분할한 만큼 그대로 사용

- `cli.py`
  - `run-session`이 teacher 1회 호출 후 teacher split을 수행하고, 각 chunk를 `qwen-computer-use-agent --prompt`로 순차 실행하도록 변경
  - 여러 agent run 결과를 한 session으로 집계
  - `--teacher-max-chunks` 제거
  - 종료 시 실행한 터미널이 다시 눈에 띄도록 best-effort attention 시도 유지

- `collector.py`
  - 다중 run을 하나의 dataset session으로 모으는 구조로 확장
  - `teacher_plan.json`, `agent_runs/*.prompt.json`, `agent_runs/*.json`, `samples.jsonl`, `session.json` 생성
  - 샘플 메타데이터에 `chunk_index`, `chunk_count`, `chunk_id`, `chunk_title`, `chunk_success_hint`, `agent_run_label` 추가

- `models.py`
  - `TeacherTaskChunk`, `TeacherChunkPlanResult` 추가

- `config/README`
  - `teacher_split_enabled`, `teacher_split_timeout_s` 반영
  - `teacher_max_chunks` 제거
  - 문서를 새 실행 구조 기준으로 갱신

## 확인 결과

실제 실행 기준으로 teacher가 생성한 긴 설치 절차를 5개 chunk로 잘 나눠서 agent가 순차 실행하는 것까지는 확인했다.

예시:
- chunk-001: 공식 다운로드 페이지 열기
- chunk-002: OS별 다운로드 진행
- chunk-003: 설치 파일 실행
- chunk-004: 로그인 완료
- chunk-005: 사용 시작 확인

즉, 긴 절차 전체를 한 번에 agent에 넣는 방식보다, 현재 상태 기준의 작은 작업으로 나눠 넣는 구조는 효과가 있었다.

## 현재 한계

현재는 chunking 자체는 성공했지만, chunk 전환 gating이 없다.

문제:
- 앞 chunk가 실제로 성공했는지 강하게 검증하지 않고 다음 chunk로 넘어간다.
- 그래서 `다운로드 실패 -> 설치 실행 시도 -> 실행 파일 없음 -> 로그인 시도` 같은 연쇄가 생길 수 있다.
- 이 상태에서 `session_outcome`이 과하게 `success`로 찍히는 경우가 있다.

예시 관찰:
- 다운로드 chunk 이후 설치 파일이 실제로 존재하지 않는데도 다음 chunk로 진행됨
- 이후 실행 파일 탐색 실패, Microsoft Store fallback 등으로 이어짐

## 다음 개선 포인트

- `success_hint` 기반으로 현재 chunk 성공 여부를 확인한 뒤에만 다음 chunk로 진행
- 실패 시 다음 chunk로 넘기지 않고 현재 chunk 재시도 또는 세션 fail 처리
- session outcome 계산도 전체 run 결과 기준으로 더 보수적으로 조정

## Codex teacher 사용 예시

모델/추론강도 지정 예시:

```bash
./.venv/bin/training-generator run-session \
  --task "pc 카카오톡 설치방법" \
  --teacher-command-template 'codex exec -m gpt-5.4-mini -c '\''model_reasoning_effort="low"'\'' "{prompt}"'
```
